### PR TITLE
add classes to html for cross-browser compatibility issues handling |…

### DIFF
--- a/cross_browser.js
+++ b/cross_browser.js
@@ -9,7 +9,7 @@ $(document).ready(function() {
     var isChrome = check(/chrome/);
     var isWebKit = check(/webkit/);
     var isOpera = check(/opera/);
-    var isOpera = check(/firefox/i);
+    var isFirefox = check(/firefox/i);
 
     var isiPad = check(/iPad/i);
     var isiOS = check(/iPad|iphone|ipod/i);
@@ -40,6 +40,10 @@ $(document).ready(function() {
 
     if(isChrome || chromeIos) {
         $('html').addClass('browser-chrome');
+    } 
+
+    if(isFirefox) {
+        $('html').addClass('browser-firefox');
     } 
 
 

--- a/cross_browser.js
+++ b/cross_browser.js
@@ -9,6 +9,7 @@ $(document).ready(function() {
     var isChrome = check(/chrome/);
     var isWebKit = check(/webkit/);
     var isOpera = check(/opera/);
+    var isOpera = check(/firefox/i);
 
     var isiPad = check(/iPad/i);
     var isiOS = check(/iPad|iphone|ipod/i);

--- a/cross_browser.js
+++ b/cross_browser.js
@@ -1,0 +1,45 @@
+$(document).ready(function() {
+
+    // http://stackoverflow.com/questions/2400935/browser-detection-in-javascript
+    var ua = navigator.userAgent.toLowerCase();
+    var check = function(r) {
+        return r.test(ua);
+    };
+
+    var isChrome = check(/chrome/);
+    var isWebKit = check(/webkit/);
+    var isOpera = check(/opera/);
+
+    var isiPad = check(/iPad/i);
+    var isiOS = check(/iPad|iphone|ipod/i);
+    var isiphone = check(/iphone/i);
+    var isChromeIos = check(/CriOS/i);
+
+    var isSafari = !isChrome && check(/safari/);
+    var isSafari2 = isSafari && check(/applewebkit\/4/); 
+    var isSafari3 = isSafari && check(/version\/3/);
+    var isSafari4 = isSafari && check(/version\/4/);
+
+    var isIE = !isOpera && check(/msie/);
+    var isIE7 = isIE && check(/msie 7/);
+    var isIE8 = isIE && check(/msie 8/);
+    var isIE6 = isIE && !isIE7 && !isIE8;
+
+
+    /**
+     * if add critical classes to html to handle special UI cases
+     */
+    if(isSafari || isSafari2  || isSafari3 || isSafari4) {
+        $('html').addClass('browser-safari');
+    } 
+
+    if(isiphone) {
+        $('html').addClass('device-iphone');  
+    }
+
+    if(isChrome || chromeIos) {
+        $('html').addClass('browser-chrome');
+    } 
+
+
+});

--- a/index.html
+++ b/index.html
@@ -17,6 +17,16 @@
 		<link rel="stylesheet" type="text/css" href="http://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css" />
 		<script src="http://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js"></script>
 		<script src='http://api.tiles.mapbox.com/mapbox.js/plugins/turf/v2.0.0/turf.min.js'></script>
+
+		<!-- Scripts -->
+		<script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+		<script src="http://code.jquery.com/ui/1.11.4/jquery-ui.min.js"></script>
+		<script src="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.1/js/bootstrap.min.js"></script>
+		<script src="http://cdnjs.cloudflare.com/ajax/libs/jasny-bootstrap/3.1.3/js/jasny-bootstrap.min.js"></script>
+
+		<!-- add css classes for cross-browser compability potential issues -->
+		<script src="cross_browser.js" type="text/javascript"></script>
+
 		<link link rel="stylesheet" type="text/css" href="voting_locations.css">
 		<!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
 		<!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
@@ -24,12 +34,6 @@
 		<script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
 		<script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
 		<![endif]-->
-
-		<!-- Scripts -->
-		<script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-		<script src="http://code.jquery.com/ui/1.11.4/jquery-ui.min.js"></script>
-		<script src="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.1/js/bootstrap.min.js"></script>
-		<script src="http://cdnjs.cloudflare.com/ajax/libs/jasny-bootstrap/3.1.3/js/jasny-bootstrap.min.js"></script>
 
 		<!-- Google Analytics -->
 		<script>


### PR DESCRIPTION
… ex: "browser-safari" within safari | customizable

Sorry for the delay. I have been pretty busy. Not sure it is still relevant for you guys.
Also I didn't change the css but now you can use:
- browser-safari class for safari
- device-iphone class for iphone
- browser-chrome class for chrome

It is of course extensible.
